### PR TITLE
fix footer

### DIFF
--- a/src/app/_components/organisms/Footer.tsx
+++ b/src/app/_components/organisms/Footer.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
                 主催:一般社団法人 PyCon JP Association
               </p>
               <p className="text-sm">
-                {`${Conference.name} hosted by PyCon JP is produced by the`}
+                {`${Conference.name} hosted by PyCon JP is produced by the `}
                 <a
                   href="https://www.pycon.jp/committee/english.html"
                   target="_blank"


### PR DESCRIPTION
page: https://2024.pycon.jp/
S/PyCon JP 2024 hosted by PyCon JP is produced by thePyCon JP Association / PyCon JP 2024 hosted by PyCon JP is produced by the PyCon JP Association.